### PR TITLE
Add human-readable From name

### DIFF
--- a/index.js
+++ b/index.js
@@ -31,6 +31,7 @@ Emailer.send = function(data, callback) {
 			to: data.to,
 			subject: data.subject,
 			from: data.from,
+			fromname: data.from_name,
 			text: data.text,
 			html: data.html
 		}, function (err, response) {


### PR DESCRIPTION
Added support for human-readable From name, so that emails do not go out with only the bare email address in From. Did this by linking from_name from NodeBB core to the SendGrid field fromname.