### PR TITLE
Closes #9

### DIFF
--- a/index.js
+++ b/index.js
@@ -173,7 +173,7 @@ Emailer.send = function (data, callback) {
 			}
 
 			data.headers = data.headers || {};	// pre core v1.10.2
-			if (data._raw.notification && data._raw.notification.pid && settings.hasOwnProperty('inbound_enabled')) {
+			if (data._raw.notification && data._raw.notification.pid && settings.inbound_enabled === 'on') {
 				data.headers['Reply-To'] = 'reply-' + data._raw.notification.pid + '@' + Emailer.hostname;
 			}
 


### PR DESCRIPTION
If the settings page was saved, then "inbound_email" was set to
"off", which satisfied the .hasOwnProperty and set the Reply-To
header.